### PR TITLE
Updated Project Settings

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -147,6 +147,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
     Android: com.DefaultCompany.HashingApp
+    Standalone: com.DefaultCompany.HashingApp
   buildNumber:
     Standalone: 0
     iPhone: 0
@@ -402,7 +403,7 @@ PlayerSettings:
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: AndroidPlayer
     m_APIs: 150000000b000000
-    m_Automatic: 0
+    m_Automatic: 1
   - m_BuildTarget: iOSSupport
     m_APIs: 10000000
     m_Automatic: 1


### PR DESCRIPTION
Enables Project Settings > Player > Auto Graphics API. This should resolve the "your device does not match the hardware requirements of this application" error on older Android devices.